### PR TITLE
Support enabling full service menu on LG CS3VA

### DIFF
--- a/ColorControl/Services/LG/LgPanel.cs
+++ b/ColorControl/Services/LG/LgPanel.cs
@@ -847,7 +847,7 @@ Do you want to continue?"
             mnuLgOLEDMotionPro.Visible = visible;
             miLgEnableMotionPro.Visible = enableVisible;
 
-            var svcMenuFlagVisible = new[] { "A2", "B2", "C2", "G2", "A3", "B3", "C3", "G3" }.Any(m => device?.ModelName?.Contains(m) == true);
+            var svcMenuFlagVisible = new[] { "A2", "B2", "C2", "G2", "A3", "B3", "C3", "G3", "CS3" }.Any(m => device?.ModelName?.Contains(m) == true);
 
             mnuLgSetSvcMenuFlag.Visible = svcMenuFlagVisible;
 


### PR DESCRIPTION
I own a LG CS3VA (2023) OLED TV, and wanted to enable the full service menu.
This model is not available worldwide, so I assume that it isn't very popular.
I patched the software so that it allows to use the service menu on my TV,  and I confirm it works.
Feel free to integrate the patch if you'd like.

P.S: You might want to add the CS2 model as well in a future patch, since I don't own it, I can't confirm that it works.