### PR TITLE
Improve Wake on Lan Code

### DIFF
--- a/Shared/Services/WolService.cs
+++ b/Shared/Services/WolService.cs
@@ -44,7 +44,7 @@ public class WolService
 
     private bool IsViableWOLInterface(NetworkInterface ni) {
         return ni.NetworkInterfaceType != NetworkInterfaceType.Loopback
-            && !ni.Name.Contains("Hyper-V")
+            && !ni.Description.Contains("Hyper-V")
             && ni.SupportsMulticast
             && ni.GetIPProperties().GetIPv4Properties != null;
     } 

--- a/Shared/Services/WolService.cs
+++ b/Shared/Services/WolService.cs
@@ -125,29 +125,21 @@ public class WolService
 
     private static void BroadcastWol(IPAddress localAddress, IPAddress broadCastAddress, byte[] data)
     {
-        //var localEP = new IPEndPoint(localAddress, 0);
-        var udpc = new UdpClient();
-
+        using var udpc = new UdpClient(new IPEndPoint(localAddress, 0));
         udpc.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, 1);
-        //udpc.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.DontRoute, 1);
 
         var target = new IPEndPoint(broadCastAddress, DefaultWolPort);
-
         udpc.Send(data, data.Length, target);
     }
 
     private static void SendWolToIpAddress(IPAddress localAddress, IPAddress remoteAddress, byte[] data, PhysicalAddress physicalAddress)
     {
-        //var localEP = new IPEndPoint(localAddress, 0);
-
         var netLuid = CreateTransientLocalNetEntry(remoteAddress, physicalAddress);
         try
         {
-            var udpc = new UdpClient();
+            using var udpc = new UdpClient(new IPEndPoint(localAddress, 0));
             udpc.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.Broadcast, 1);
-
             var target = new IPEndPoint(remoteAddress, DefaultWolPort);
-
             udpc.Send(data, data.Length, target);
         }
         finally

--- a/Shared/Services/WolService.cs
+++ b/Shared/Services/WolService.cs
@@ -44,7 +44,7 @@ public class WolService
 
     private bool IsViableWOLInterface(NetworkInterface ni) {
         return ni.NetworkInterfaceType != NetworkInterfaceType.Loopback
-            && ni.Name.Contains("Hyper-V")
+            && !ni.Name.Contains("Hyper-V")
             && ni.SupportsMulticast
             && ni.GetIPProperties().GetIPv4Properties != null;
     } 


### PR DESCRIPTION
Sometimes my LG C3 won't wake up from ColorControl's WOL but from other Software. When sending the WOL Packet, WireShark doesn't recognize the protocol of the package as WOL but as DISCARD editing the default port to 0 makes it recognized as WOL. Explicitly ignore Hyper-V Default Switch as well. 

Methods also changed to be more readable. WOL Password removed since it is not used anywhere else in the Code.