### PR TITLE
fix: update LG webOS register payload for webOS 26 compatibility

### DIFF
--- a/ColorControl/Resources/LG_register.json
+++ b/ColorControl/Resources/LG_register.json
@@ -1,77 +1,69 @@
-﻿{
-   "type":"register",
-   "id":"register_0",
-   "payload":{
-      "forcePairing":false,
-      "pairingType":"PROMPT",
-      "client-key":"CLIENTKEYGOESHERE",
-      "manifest":{
-         "manifestVersion":1,
-         "appVersion":"1.1",
-         "signed":{
-            "created":"20140509",
-            "appId":"com.lge.test",
-            "vendorId":"com.lge",
-            "localizedAppNames":{
-               "":"LG Remote App",
-               "ko-KR":"리모컨 앱",
-               "zxx-XX":"ЛГ Rэмotэ AПП"
-            },
-            "localizedVendorNames":{
-               "":"LG Electronics"
-            },
-            "permissions":[
-               "TEST_SECURE",
-               "CONTROL_INPUT_TEXT",
-               "CONTROL_MOUSE_AND_KEYBOARD",
-               "READ_INSTALLED_APPS",
-               "READ_LGE_SDX",
-               "READ_NOTIFICATIONS",
-               "SEARCH",
-               "WRITE_SETTINGS",
-               "WRITE_NOTIFICATION_ALERT",
-               "CONTROL_POWER",
-               "READ_CURRENT_CHANNEL",
-               "READ_RUNNING_APPS",
-               "READ_UPDATE_INFO",
-               "UPDATE_FROM_REMOTE_APP",
-               "READ_LGE_TV_INPUT_EVENTS",
-               "READ_TV_CURRENT_TIME"
-            ],
-            "serial":"2f930e2d2cfe083771f68e4fe7bb07"
-         },
-         "permissions":[
-            "LAUNCH",
-            "LAUNCH_WEBAPP",
-            "APP_TO_APP",
-            "CLOSE",
-            "TEST_OPEN",
-            "TEST_PROTECTED",
-            "CONTROL_AUDIO",
-            "CONTROL_DISPLAY",
-            "CONTROL_INPUT_JOYSTICK",
-            "CONTROL_INPUT_MEDIA_RECORDING",
-            "CONTROL_INPUT_MEDIA_PLAYBACK",
-            "CONTROL_INPUT_TV",
-            "CONTROL_POWER",
-            "CONTROL_TV_SCREEN",
-            "READ_APP_STATUS",
-            "READ_CURRENT_CHANNEL",
-            "READ_INPUT_DEVICE_LIST",
-            "READ_NETWORK_STATE",
-            "READ_RUNNING_APPS",
-            "READ_TV_CHANNEL_LIST",
-            "WRITE_NOTIFICATION_TOAST",
-            "READ_POWER_STATE",
-            "READ_COUNTRY_INFO",
-            "READ_SETTINGS"
-         ],
-         "signatures":[
-            {
-               "signatureVersion":1,
-               "signature":"eyJhbGdvcml0aG0iOiJSU0EtU0hBMjU2Iiwia2V5SWQiOiJ0ZXN0LXNpZ25pbmctY2VydCIsInNpZ25hdHVyZVZlcnNpb24iOjF9.hrVRgjCwXVvE2OOSpDZ58hR+59aFNwYDyjQgKk3auukd7pcegmE2CzPCa0bJ0ZsRAcKkCTJrWo5iDzNhMBWRyaMOv5zWSrthlf7G128qvIlpMT0YNY+n/FaOHE73uLrS/g7swl3/qH/BGFG2Hu4RlL48eb3lLKqTt2xKHdCs6Cd4RMfJPYnzgvI4BNrFUKsjkcu+WD4OO2A27Pq1n50cMchmcaXadJhGrOqH5YmHdOCj5NSHzJYrsW0HPlpuAx/ECMeIZYDh6RMqaFM2DXzdKX9NmmyqzJ3o/0lkk/N97gfVRLW5hA29yeAwaCViZNCP8iC9aO0q9fQojoa7NQnAtw=="
-            }
-         ]
-      }
-   }
+{
+  "type": "register",
+  "id": "register_0",
+  "payload": {
+    "forcePairing": false,
+    "pairingType": "PROMPT",
+    "client-key": "CLIENTKEYGOESHERE",
+    "manifest": {
+      "manifestVersion": 1,
+      "appVersion": "1.0",
+      "signed": {
+        "appId": "com.colorcontrol.app",
+        "created": "20260426",
+        "localizedAppNames": {
+          "": "ColorControl"
+        },
+        "localizedVendorNames": {
+          "": "ColorControl"
+        },
+        "permissions": [
+          "CONTROL_POWER",
+          "READ_POWER_STATE",
+          "READ_CURRENT_CHANNEL",
+          "READ_RUNNING_APPS",
+          "READ_NETWORK_STATE",
+          "READ_INPUT_DEVICE_LIST",
+          "READ_TV_CHANNEL_LIST",
+          "READ_SETTINGS",
+          "READ_COUNTRY_INFO",
+          "WRITE_NOTIFICATION_TOAST",
+          "CONTROL_AUDIO",
+          "CONTROL_DISPLAY",
+          "CONTROL_INPUT_JOYSTICK",
+          "CONTROL_INPUT_MEDIA_PLAYBACK",
+          "CONTROL_INPUT_TV",
+          "CONTROL_TV_SCREEN",
+          "LAUNCH",
+          "LAUNCH_WEBAPP",
+          "APP_TO_APP",
+          "CLOSE"
+        ],
+        "serial": "colorcontrol-webos26"
+      },
+      "permissions": [
+        "LAUNCH",
+        "LAUNCH_WEBAPP",
+        "APP_TO_APP",
+        "CLOSE",
+        "CONTROL_AUDIO",
+        "CONTROL_DISPLAY",
+        "CONTROL_INPUT_JOYSTICK",
+        "CONTROL_INPUT_MEDIA_PLAYBACK",
+        "CONTROL_INPUT_TV",
+        "CONTROL_POWER",
+        "CONTROL_TV_SCREEN",
+        "READ_APP_STATUS",
+        "READ_CURRENT_CHANNEL",
+        "READ_INPUT_DEVICE_LIST",
+        "READ_NETWORK_STATE",
+        "READ_RUNNING_APPS",
+        "READ_TV_CHANNEL_LIST",
+        "WRITE_NOTIFICATION_TOAST",
+        "READ_POWER_STATE",
+        "READ_COUNTRY_INFO",
+        "READ_SETTINGS"
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- replace the old LG webOS register payload in `ColorControl/Resources/LG_register.json`
- remove the fixed legacy signature blob that can be rejected by newer webOS versions
- use a simpler prompt-based register manifest that works better with webOS 26

## Why
On newer LG TVs running webOS 26, the old register payload may fail during pairing with:

`403 Pairing rejected: blacklisted certificate detected`

This change updates the handshake payload to avoid the legacy blacklisted signature format while preserving the normal `client-key` pairing flow.
